### PR TITLE
yellow and hex code identifier

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@ struct Color {
 };
 
 Color getColor(char* color, unsigned char maxval) {
-	if((color[0]) == '#') {
+	if(((color[0]) == '#')  || ((color[0]) == '_')) {
 		if(strlen(color) != 7) {
 			return Color();
 		}
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 			}
 			lamp.close();
 		} else {
-			std::cout << "no lamp forun" << std::endl;
+			std::cout << "no lamp found" << std::endl;
 		}
 
 	} else {


### PR DESCRIPTION
Hi Daniel,

I added yellow as one of the secondary colors.

Additionally I added '_' as identifier for the hexcode parameter. It took some time till I realized that my shell was interpreting the hash as a comment. That should probably be added to the README as well :-)

Regards,
Stefan
