### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -20,6 +20,6 @@
 #include "Color.hpp"
 
 Color::Color() : red(0), green(0), blue(0) { }
-Color::Color(unsigned char r, unsigned char g, unsigned char b) : red(r), green(g), blue(b) { }
+Color::Color(char r, char g, char b) : red(r), green(g), blue(b) { }
 
 // vim: noai:ts=4:sw=4

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -21,10 +21,10 @@
 #define	COLOR_H
 
 struct Color {
-	const static unsigned char maxval = 0x40; // Brightest value
-	unsigned char red, green, blue;
+	const static char maxval = 0x40; // Brightest value
+	char red, green, blue;
 	Color();
-	Color(unsigned char r, unsigned char g, unsigned char b);
+	Color(char r, char g, char b);
 };
 #endif	/* COLOR_H */
 


### PR DESCRIPTION
Fixes these warnings:

```
USBLamp.cpp: In member function ‘void USBLamp::setColor(Color)’:
USBLamp.cpp:98:84: warning: narrowing conversion of ‘((USBLamp*)this)->USBLamp::color.Color::red’ from ‘unsigned char’ to ‘char’ inside { } is ill-formed in C++11 [-Wnarrowing]
     char data[] = {color.red, color.green, color.blue, 0x00, 0x00, 0x00, 0x00, 0x05};
                                                                                    ^
USBLamp.cpp:98:84: warning: narrowing conversion of ‘((USBLamp*)this)->USBLamp::color.Color::green’ from ‘unsigned char’ to ‘char’ inside { } is ill-formed in C++11 [-Wnarrowing]
USBLamp.cpp:98:84: warning: narrowing conversion of ‘((USBLamp*)this)->USBLamp::color.Color::blue’ from ‘unsigned char’ to ‘char’ inside { } is ill-formed in C++11 [-Wnarrowing]
```
