### PR TITLE
Use install(1) to install usblamp

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,9 +8,7 @@ main: $(SRC)
 	$(CC) $(CFLAGS) -o $(BIN) $+ $(LIBS)
 
 install:
-	cp $(BIN) /usr/bin/$(BIN)
-	chown root:root /usr/bin/$(BIN)
-	chmod u+s /usr/bin/$(BIN)
+	install -m 4755 $(BIN) /usr/bin
 
 archive_dir = /tmp/usblamp
 file_name = usblamp.sh


### PR DESCRIPTION
I've omitted -o and -g, as those will be set to root:root by default.

Also, please note `install-script` makes insecure use of /tmp/. I recommend deleting this target.
