### PR TITLE
Improve invocation of /usr/bin/usblamp

### DIFF
--- a/scripts/usblamp.py
+++ b/scripts/usblamp.py
@@ -18,6 +18,5 @@
 import subprocess
 
 def switchTo(color):
-    shell = "usblamp %s" % color
-    subprocess.Popen([shell], shell=True, stdout=subprocess.PIPE, close_fds=True)
+    subprocess.Popen(["usblamp", color], stdout=subprocess.PIPE, close_fds=True)
 


### PR DESCRIPTION
`shell=True` is considered [harmful](https://docs.python.org/2/library/subprocess.html). It's safer to call usblamp this way.
